### PR TITLE
Added config to set the text editor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ If the configuration directory does not exist, you can initialize the directory 
 
 The following configurations can be configured in `config.json`:
 
-| Key             | Example Value          | Description                                                         |
+| Key             | Example Values          | Description                                                         |
 | --------------- | ---------------------- | ------------------------------------------------------------------  |
-| "NotesLocation" | "/home/user/Documents" | Defines the absolute directory path where the notes will be stored. |
+| "NotesLocation" | "/home/user" | Defines the absolute path where the notes will be stored. |
+| "FileExtension" | "txt and md" | Defines file extension that will be used to save the notes files. The default value is "md". |
+| "TextEditorCommand" | "vi, nano, and vim" | Command that invokes a text editor with a specified filename as an argument, allowing the user to view and modify the contents of that file. The default value is "vi". |
+

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -8,14 +8,15 @@ import (
 	"strings"
 )
 
-const notesLocationKey = "NotesLocation"
-
 type Configuration struct {
-	NotesLocation string `json:"NotesLocation"`
-	FileExtension string `json:"FileExtension"`
+	NotesLocation     string `json:"NotesLocation"`
+	FileExtension     string `json:"FileExtension"`
+	TextEditorCommand string `json:"TextEditorCommand"`
 }
 
+const notesLocationKey = "NotesLocation"
 const defaultFileExtension string = "md"
+const defaultTextEditorCommand string = "vi"
 
 func Get() (*Configuration, error) {
 	filepath, err := GetFileAbsolutePath()
@@ -35,7 +36,8 @@ func Get() (*Configuration, error) {
 	defer jsonFile.Close()
 
 	config := Configuration{
-		FileExtension: defaultFileExtension,
+		FileExtension:     defaultFileExtension,
+		TextEditorCommand: defaultTextEditorCommand,
 	}
 
 	byteValue, _ := io.ReadAll(jsonFile)

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/user"
 )
 
 func Initialize() error {
@@ -24,7 +25,12 @@ func Initialize() error {
 			return err
 		}
 
-		_, err = file.WriteString("{\n    \"" + notesLocationKey + "\":\"~/Documents\"\n}")
+		user, err := user.Current()
+		if err != nil {
+			return err
+		}
+
+		_, err = file.WriteString("{\n    \"" + notesLocationKey + "\":\"" + user.HomeDir + "\"\n}")
 		if err != nil {
 			return nil
 		}

--- a/internal/notes/create.go
+++ b/internal/notes/create.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+
+	"github.com/joshmalbrecht/note/internal/config"
 )
 
 // Create creates a new note file at the provided filepath with a formatted file name based on the provided title.
@@ -23,7 +25,12 @@ func Create(filepath string, title string, fileExtension string) (string, bool, 
 		return "", false, err
 	}
 
-	cmd := exec.Command("vi", filename)
+	configurations, err := config.Get()
+	if err != nil {
+		return "", false, err
+	}
+
+	cmd := exec.Command(configurations.TextEditorCommand, filename)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 


### PR DESCRIPTION
- Added a configuration that defines the text editor command that will be used to edit note files.
- Set the default value for the text editor command to "vi".
- Updated the README.md to reflect the new configurations.
- Updated the "NotesLocation" configuration value to be the user's home directory when initializing the config.json.