### PR TITLE
Removed the default 'completion' command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,9 @@ func Execute() {
 }
 
 func init() {
+	// Disable the default 'completion' command
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	rootCmd.AddCommand(versionCmd)
 }
 


### PR DESCRIPTION
- Cobra CLI adds a default 'completion' command and to remove this command, I set the DisableDefaultCmd completion option to 'true'.