### PR TITLE
(#20) Removed segmentation fault when adding note with no config

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/joshmalbrecht/note/internal/config"
 	"github.com/joshmalbrecht/note/internal/notes"
@@ -15,12 +16,13 @@ var addCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			fmt.Println("Must provide only one argument")
-			return
+			os.Exit(1)
 		}
 
 		configurations, err := config.Get()
 		if err != nil {
 			fmt.Println("unable to read config: " + err.Error())
+			os.Exit(1)
 		}
 
 		title := args[0]
@@ -28,7 +30,7 @@ var addCmd = &cobra.Command{
 		filename, created, err := notes.Create(configurations.NotesLocation, title, configurations.FileExtension)
 		if err != nil {
 			fmt.Println("Unable to create note: " + err.Error())
-			return
+			os.Exit(1)
 		}
 
 		if created {
@@ -36,6 +38,8 @@ var addCmd = &cobra.Command{
 		} else {
 			fmt.Println("Empty note was not created")
 		}
+
+		os.Exit(0)
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/joshmalbrecht/note/internal/config"
 	"github.com/spf13/cobra"
@@ -15,7 +16,10 @@ var initCmd = &cobra.Command{
 		err := config.Initialize()
 		if err != nil {
 			fmt.Println("unable to initialize: " + err.Error())
+			os.Exit(1)
 		}
+
+		os.Exit(0)
 	},
 }
 

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"strings"
@@ -18,14 +17,32 @@ const notesLocationKey = "NotesLocation"
 const defaultFileExtension string = "md"
 const defaultTextEditorCommand string = "vi"
 
+func Exists() (bool, error) {
+	filepath, err := GetFileAbsolutePath()
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func Get() (*Configuration, error) {
 	filepath, err := GetFileAbsolutePath()
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		return nil, errors.New("configuration file does not exist")
+	exists, err := Exists()
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		Initialize()
 	}
 
 	jsonFile, err := os.Open(filepath)

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Initialize() error {
+	fmt.Println("initializing the configuration file ...")
+
 	filepath, err := GetDirectory()
 	if err != nil {
 		return err

--- a/internal/notes/file.go
+++ b/internal/notes/file.go
@@ -13,7 +13,6 @@ import (
 )
 
 const notesDirName string = "notes-cli"
-
 const dateFormat string = "2006-01-02"
 
 func createNewNoteFile(path string, title string, fileExtension string) (string, error) {


### PR DESCRIPTION
- Updated the 'add' command to initialize the configuration file if the file does not exist when the user uses the 'add' command.