### PR TITLE
(#23) Updated the edit command to use the TextEditorCommand config

### DIFF
--- a/internal/notes/edit.go
+++ b/internal/notes/edit.go
@@ -3,6 +3,8 @@ package notes
 import (
 	"os"
 	"os/exec"
+
+	"github.com/joshmalbrecht/note/internal/config"
 )
 
 // Edit will open an editor for the file with the provided name.
@@ -12,7 +14,12 @@ func Edit(filename string) error {
 		return err
 	}
 
-	cmd := exec.Command("vi", filepath)
+	configurations, err := config.Get()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(configurations.TextEditorCommand, filepath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 


### PR DESCRIPTION
- The edit command was hard coded to use 'vi' to edit the file, but this was updated to use the TextEditorCommand configuration.